### PR TITLE
Add feature to visibly highlight user's selected answer

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -28,6 +28,7 @@ const initialState = {
   quizTopic: "React",
   activeQuestions: [],
   modalIsOpen: false,
+  selectedAnswer: null,
 };
 
 function reducer(state, action) {
@@ -61,6 +62,7 @@ function reducer(state, action) {
           action.payload === question.correctOption
             ? state.points + question.points
             : state.points,
+        selectedAnswer: action.payload,
       };
     case "nextQuestion":
       return {
@@ -93,11 +95,16 @@ function reducer(state, action) {
       return {
         ...state,
         index: action.payload - 1,
+        selectedAnswer: state.answer[action.payload - 1],
       };
     case "navigateRight":
       return {
         ...state,
         index: action.payload + 1,
+        selectedAnswer:
+          state.answer[action.payload + 1] != null
+            ? state.answer[action.payload + 1]
+            : null,
       };
     case "changeTopic":
       return {
@@ -133,6 +140,7 @@ export default function App() {
       questionAmount,
       activeQuestions,
       modalIsOpen,
+      selectedAnswer,
     },
     dispatch,
   ] = useReducer(reducer, initialState);
@@ -191,6 +199,7 @@ export default function App() {
               answer={answer}
               index={index}
               numQuestions={numQuestions}
+              selectedAnswer={selectedAnswer}
             />
             <Footer>
               <Timer dispatch={dispatch} secondsRemaining={secondsRemaining} />

--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -1,4 +1,4 @@
-function Options({ question, dispatch, answer, index, hasAnswered }) {
+function Options({ question, dispatch, answer, hasAnswered, selectedAnswer }) {
   return (
     <div className="options">
       {question.options.map((option, index) => (
@@ -10,7 +10,14 @@ function Options({ question, dispatch, answer, index, hasAnswered }) {
                 ? "correct"
                 : "wrong"
               : ""
-          }`}
+          }
+        ${
+          hasAnswered
+            ? selectedAnswer === index
+              ? "selected-answer"
+              : "faded"
+            : ""
+        }`}
           disabled={hasAnswered}
           key={option}
           onClick={() => dispatch({ type: "newAnswer", payload: index })}

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -2,7 +2,14 @@ import NextButton from "./NextButton";
 import Options from "./Options";
 import PrevButton from "./PrevButton";
 
-function Question({ question, dispatch, answer, index, numQuestions }) {
+function Question({
+  question,
+  dispatch,
+  answer,
+  index,
+  numQuestions,
+  selectedAnswer,
+}) {
   const hasAnswered = answer.length > index;
   return (
     <div className="question">
@@ -21,6 +28,7 @@ function Question({ question, dispatch, answer, index, numQuestions }) {
           answer={answer}
           index={index}
           hasAnswered={hasAnswered}
+          selectedAnswer={selectedAnswer}
         />
       </main>
       <NextButton

--- a/src/index.css
+++ b/src/index.css
@@ -191,14 +191,19 @@ progress {
   border: 2px solid var(--color-theme);
   color: var(--color-light);
 }
+
 .btn-option.wrong {
   background-color: var(--color-accent);
   border: 2px solid var(--color-accent);
   color: var(--color-darkest);
 }
 
-.answer {
+.answer,
+.selected-answer {
   transform: translateX(2rem);
+}
+.btn-option.faded {
+  opacity: 0.3;
 }
 
 .result {


### PR DESCRIPTION
Fixes #3

By introducing the `selectedAnswer` state, which holds an array, we're able to store the user's selections for each question. This array serves two main purposes:

1. **Persistence**: Even if the user navigates away from a question and then returns to it, their original answer will still be highlighted because we've saved it in our state. This ensures a user doesn't lose context or get confused about their past actions.
2. **Styling Consistency**: Since we know which option the user selected for every question, we can apply consistent styling. For instance, if the user selected the second option for a question, that particular option button can be styled differently (like being highlighted) to indicate the user's choice.

This state management approach helps improve the UX by giving users a visual cue of their past selections, ensuring they don't have to rely on memory alone.

![quiz-app-issue-3](https://github.com/ronnieima/quiz-app/assets/70875687/c425ff73-b274-4556-9252-611e8d4a5c2a)
